### PR TITLE
remove example.JSON

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         "guzzlehttp/guzzle": "^6.3",
         "laravel/framework": "^7.0",
         "laravel/homestead": "^10.10",
-        "laravel/passport": "^9.3",
+        "laravel/passport": "^10.0",
         "laravel/tinker": "^2.0",
         "mailjet/mailjet-apiv3-php": "^1.4",
         "nesbot/carbon": "^2.38",


### PR DESCRIPTION
Now that the API documentation more accurately describes the JSON that is returned as referenced by commit https://github.com/develop-me/bagajob-API/commit/4a1f480bdb36ae5d1001c76a267cb44227b9d714, `example.json` can be deleted and Issue https://github.com/develop-me/bagajob-API/issues/14 can be closed.