### PR TITLE
configure .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,8 @@
-APP_NAME=Laravel
+APP_NAME=Bagajob
 APP_ENV=local
-APP_KEY= *****
+APP_KEY=*****
 APP_DEBUG=true
-APP_URL=http://localhost
+APP_URL=http://homestead.test/
 
 LOG_CHANNEL=stack
 
@@ -11,7 +11,7 @@ DB_HOST=127.0.0.1
 DB_PORT=3306
 DB_DATABASE=homestead
 DB_USERNAME=root
-DB_PASSWORD= *****
+DB_PASSWORD=*****
 
 BROADCAST_DRIVER=log
 CACHE_DRIVER=file
@@ -47,11 +47,14 @@ MIX_PUSHER_APP_CLUSTER="${PUSHER_APP_CLUSTER}"
 
 ADMIN_USER_NAME="Bagajob Admin"
 ADMIN_USER_EMAIL=bagajob.mail@gmail.com
-ADMIN_USER_PASSWORD= *****
+ADMIN_USER_PASSWORD=*****
 
 MAIL_FROM_ADDRESS=bagajob.mail@gmail.com
 MAIL_FROM_NAME="${APP_NAME}"
 
+# to retrieve MAILJET_APIKEY & MAILJET_APISECRET, sign in to https://app.mailjet.com/ and enter the ADMIN_USER_EMAIL and ADMIN_USER_PASSWORD for access.
+# At https://app.mailjet.com/account/setup, use the API_KEY and SECRET_KEY shown for the below fields.
+
 MAIL_DRIVER=mailjet
-MAILJET_APIKEY= *****
-MAILJET_APISECRET= *****
+MAILJET_APIKEY=*****
+MAILJET_APISECRET=*****


### PR DESCRIPTION
**Issue:**

- Password reset requests fail with 400 Bad request on local machines

**Reason:**

- `.env.example` is incorrectly configured for mailjet functionality

**Action:**

- `.env.example` has now been updated with the correct information
- passwords have been obscured in `.env.example`
- instructions are included in `.env.example` for retrieving `MAILJET_APIKEY` and `MAILJET_APISECRET`