### PR TITLE
add cv and coverletter to jobs table

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,9 @@ Visit `http://homestead.test` on Mac or `http://localhost:8000` on Windows:
 
 ### Troubleshooting:
 
+### Q: After running a database refresh/seed authentication is broken?
+A: Run `artisan passport:install` to create the personal access client keys again
+
 ### Q: When I run `composer install` I get a memory error
 A: 
 
@@ -481,6 +484,8 @@ Returns an individual job as JSON object where `:jobId` is the job ID
         "date_applied": null,
         "description": "Dicta dolorem aut id porro ut porro sit. Expedita nemo vel natus eos ipsa quasi. Deleniti placeat non qui quibusdam adipisci amet et at.",
         "stage": "1",
+        "cv": "CV_June_2020.pdf", // string of the filename, not actually storing files at this time
+        "cover_letter": "fullstack_cover_July_2020.pdf", // string of the filename, not actually storing files at this time
         "interviews": ["..."],
         "application_notes": ["..."]
     }

--- a/database/factories/JobFactory.php
+++ b/database/factories/JobFactory.php
@@ -16,5 +16,7 @@ $factory->define(Job::class, function (Faker $faker) {
         'closing_date' => $faker->dateTimeBetween($startDate = 'now', $endDate = '+1 years', $timezone = 'GMT'),
         'date_applied' => $faker->dateTime($max = 'now'),
         'location' => $faker->city(),
+        'cv' => 'CV_June_2020.pdf',
+        'cover_letter' => 'fullstack_cover_July_2020.pdf'
     ];
 });

--- a/database/migrations/2020_09_25_174135_add_cv_coverletter_to_jobs_table.php
+++ b/database/migrations/2020_09_25_174135_add_cv_coverletter_to_jobs_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCvCoverletterToJobsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('jobs', function (Blueprint $table) {
+            // add string column for CV and Cover letter for MVP
+            $table->string('cv')->nullable();
+            $table->string('cover_letter')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('jobs', function (Blueprint $table) {
+            // remove
+            $table->dropColumn('cv');
+            $table->dropColumn('cover_letter');
+        });
+    }
+}


### PR DESCRIPTION
## Summary
- Added columns in the Jobs table to store a string of the filename of the cv and cover letter for a specific job
- We aren't actually allowing upload of the files at this time. The idea is the end user just puts in the filename that they used for that particular job and stores the files locally.

Example (these are part of Jobs):
```
{
        "cv": "CV_June_2020.pdf", // string of the filename, not actually storing files at this time
        "cover_letter": "fullstack_cover_July_2020.pdf", // string of the filename, not actually storing files at this time
}
```