### PR TITLE
revert interview column name 'date' to 'interview_date'

### DIFF
--- a/app/Http/Requests/API/InterviewRequest.php
+++ b/app/Http/Requests/API/InterviewRequest.php
@@ -26,7 +26,7 @@ class InterviewRequest extends FormRequest
     {
         return [
                 //validation rules for interview creation
-                'date' => ['required', 'date'],
+                'interview_date' => ['required', 'date'],
                 'format' => [
                     'required', 
                     Rule::in([ 'online_testing','telephone', 'video_call', 'in_person',]), 

--- a/app/Http/Resources/API/InterviewResource.php
+++ b/app/Http/Resources/API/InterviewResource.php
@@ -17,7 +17,7 @@ class InterviewResource extends JsonResource
         return [
             'id' => $this->id,
             'job_id' => $this->job_id,
-            'date' => $this->date,
+            'interview_date' => $this->interview_date,
             'format' => $this->format,
             'interviewer' => $this->interviewer,
             'notes' => $this->notes,

--- a/app/Interview.php
+++ b/app/Interview.php
@@ -12,7 +12,7 @@ class Interview extends Model
      * @var array
      */
     protected $fillable = [
-        'date',
+        'interview_date',
         'format',
         'interviewer',
         'notes'

--- a/database/factories/InterviewFactory.php
+++ b/database/factories/InterviewFactory.php
@@ -7,7 +7,7 @@ use Faker\Generator as Faker;
 
 $factory->define(Interview::class, function (Faker $faker) {
     return [
-        'date' => $faker->date(),
+        'interview_date' => $faker->date(),
         'format' => $faker->randomElement($array = array ('online_testing','telephone', 'video_call', 'in_person',)),
         'interviewer' => $faker->name(),
         'notes' => $faker->paragraph($nbSentences = 3, $variableNbSentences = true)

--- a/database/migrations/2020_09_29_142823_revert_date_column_name_to_interview_date.php
+++ b/database/migrations/2020_09_29_142823_revert_date_column_name_to_interview_date.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RevertDateColumnNameToInterviewDate extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('interviews', function (Blueprint $table) {
+            $table->renameColumn('date', 'interview_date');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('interviews', function (Blueprint $table) {
+            $table->renameColumn('interview_date', 'date');
+        });
+    }
+}


### PR DESCRIPTION
**Issue:**

The front-end uses the local state of the JobForms component to store user input as variables before dispatching it to the API: 

```
const {
    job: {
            title,
            company,
            description,
            salary,
            location,
            date_applied,
            closing_date,
            cv,
            cover_letter,
            active,
            stage
        },
    interview : {
            interview_date,
            format,
            interviewer,
            notes
        },
    application_notes : {
            date,
            data
        },
    }
}
```

If the front end changes `interview_date` to `date`, the `date` variable will be declared twice: one in `interview` and once in `application_notes`. Whilst it would be possible to resolve this by changing the structure of the form and the way the data is dispatched, and whilst `date` is a more appropriate column name than `interview_date`, renaming the column back to `interview_date` would not be inappropriate, and is a much less labour-intensive and more efficient solution.

**Action:** 

Migration created to change `date` column of `interviews` table back to `interview_date`