### PR TITLE
Fix forgot password url in email

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=*****
 APP_DEBUG=true
 APP_URL=http://homestead.test/
+CLIENT_URL=https://bagajob.developme.space/
 
 LOG_CHANNEL=stack
 

--- a/app/Http/Controllers/API/AuthController.php
+++ b/app/Http/Controllers/API/AuthController.php
@@ -76,8 +76,8 @@ class AuthController extends Controller
         ->where('email', $userEmail)->first();
         
         // Generate, the password reset link. The email and token generated is embedded in the link
-        $link = config('app.url') . 'password-reset/?email=' . urlencode($user->email) . '&' . 'token=' . urlencode($tokenData->token);
-        
+        $link = config('app.client_url') . 'password-reset/?email=' . urlencode($user->email) . '&' . 'token=' . urlencode($tokenData->token);
+
         // Create Mailable Object for the Email
         $emailTemplate = (new ResetPassword($link))
             ->to($user)

--- a/config/app.php
+++ b/config/app.php
@@ -53,6 +53,7 @@ return [
     */
 
     'url' => env('APP_URL', 'http://localhost'),
+    'client_url' => env('CLIENT_URL', 'http://localhost'),
 
     'asset_url' => env('ASSET_URL', null),
 


### PR DESCRIPTION
Previously the backend was using the "APP_URL" evironment variable to make the url for the forgot password email
This is incorrect as this URL should be the "client" URL or frontend. 

I've added a new environment variable "CLIENT_URL"=https://bagajob.developme.space/ to contain the url of the client and used this in the email.
﻿
